### PR TITLE
[FEAT] 판매 게시글 수정 데이터 반환

### DIFF
--- a/src/main/java/com/planty/controller/board/BoardController.java
+++ b/src/main/java/com/planty/controller/board/BoardController.java
@@ -95,6 +95,24 @@ public class BoardController {
         return ResponseEntity.ok(dto);
     }
 
+    // 판매 게시글 수정 전 데이터
+    @GetMapping("/details/update/{id}")
+    public ResponseEntity<BoardUpdateResDto> getBoardUpdateDetail(
+            @AuthenticationPrincipal CustomUserDetails me,
+
+            // 게시글 id
+            @PathVariable Integer id
+    ) {
+        // 권한이 없을 떄
+        if (me == null) return ResponseEntity.status(401).build();
+
+        // 판매 게시글 수정 데이터 가져오기
+        BoardUpdateResDto dto = boardService.getBoardUpdate(id, me.getId());
+
+        // 판매 게시글 데이터 반환
+        return ResponseEntity.ok(dto);
+    }
+
     // 판매 게시글 수정 (JSON + 파일)
     @PutMapping(value="/details/{id:\\d+}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<?> updateBoard(

--- a/src/main/java/com/planty/dto/board/BoardDetailDto.java
+++ b/src/main/java/com/planty/dto/board/BoardDetailDto.java
@@ -9,7 +9,6 @@ import java.util.List;
 @Getter @Builder
 public class BoardDetailDto {
     private Integer boardId;
-    private Integer cropId;
     private String title;
     private String content;
     private Integer price;

--- a/src/main/java/com/planty/dto/board/BoardUpdateResDto.java
+++ b/src/main/java/com/planty/dto/board/BoardUpdateResDto.java
@@ -1,0 +1,15 @@
+package com.planty.dto.board;
+
+import com.planty.dto.crop.CropDetailsDto;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+
+// 판매 게시글 수정 전 프론트에게 전달하는 DTO
+@Getter @Setter
+@Builder
+public class BoardUpdateResDto {
+    private CropDetailsDto cropDetailsDto;
+    private BoardDetailDto boardDetailDto;
+}

--- a/src/main/java/com/planty/service/board/BoardService.java
+++ b/src/main/java/com/planty/service/board/BoardService.java
@@ -115,7 +115,6 @@ public class BoardService {
         // 판매 게시글 정보
         BoardDetailDto boardDetailDto = BoardDetailDto.builder()
                 .boardId(board.getId())
-                .cropId(board.getCrop().getId())
                 .title(board.getTitle())
                 .content(board.getContent())
                 .price(board.getPrice())
@@ -152,7 +151,6 @@ public class BoardService {
         // 판매 게시글 정보
         BoardDetailDto boardDetailDto = BoardDetailDto.builder()
                 .boardId(board.getId())
-                .cropId(board.getCrop().getId())
                 .title(board.getTitle())
                 .content(board.getContent())
                 .price(board.getPrice())

--- a/src/main/java/com/planty/service/board/BoardService.java
+++ b/src/main/java/com/planty/service/board/BoardService.java
@@ -1,6 +1,7 @@
 package com.planty.service.board;
 
 import com.planty.dto.board.*;
+import com.planty.dto.crop.CropDetailsDto;
 import com.planty.entity.board.Board;
 import com.planty.entity.board.BoardImage;
 import com.planty.entity.crop.Crop;
@@ -18,6 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -129,6 +131,48 @@ public class BoardService {
                 .seller(sellerDto)
                 .board(boardDetailDto)
                 .isOwner(isOwner)
+                .build();
+    }
+
+    // 판매 게시글 수정 페이지 정보 반환
+    public BoardUpdateResDto getBoardUpdate(Integer id, Integer meId) {
+        // 판매 게시글 소유권 검증
+        Board board = requireOwnBoard(id, meId);
+
+        Crop crop = cropRepository.findById(board.getCrop().getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "NOT_FOUND"));
+
+        // 판매 게시글 이미지 처리
+        List<String> images = Optional.ofNullable(board.getImages())
+                .orElse(Collections.emptyList())
+                .stream()
+                .map(BoardImage::getBoardImg)
+                .toList();
+
+        // 판매 게시글 정보
+        BoardDetailDto boardDetailDto = BoardDetailDto.builder()
+                .boardId(board.getId())
+                .cropId(board.getCrop().getId())
+                .title(board.getTitle())
+                .content(board.getContent())
+                .price(board.getPrice())
+                .sell(board.getSell())
+                .images(images)
+                .build();
+
+        // 판매 게시글 작물 불러오기
+        CropDetailsDto cropDetailsDto = CropDetailsDto.builder()
+                .cropId(crop.getId())
+                .name(crop.getName())
+                .cropImg(crop.getCropImg())
+                .startAt(crop.getStartAt())
+                .endAt(crop.getEndAt())
+                .build();
+
+        // 프론트에 보내주는 DTO 반환
+        return BoardUpdateResDto.builder()
+                .cropDetailsDto(cropDetailsDto)
+                .boardDetailDto(boardDetailDto)
                 .build();
     }
 


### PR DESCRIPTION
## ✨ 작업 개요
<!-- 어떤 기능을 구현했는지 간단히 설명해주세요 -->
- 판매 게시글 수정 데이터 반환
- 판매 게시글 상세 열람 시 cropId 반환하지 않게 수정
---

## 🔗 포스트맨 이미지
<img width="595" height="1031" alt="image" src="https://github.com/user-attachments/assets/fa69a9c1-1e2d-4389-b55c-d2ba25f25948" />

---

## 📂 변경 사항
<!-- 코드/폴더/파일 구조 변경이 있다면 작성 -->

---

## 📝 비고
<!-- 추가로 전달할 사항 -->